### PR TITLE
docs: import macros from `servify` instead of `servify_macro`

### DIFF
--- a/.changeset/sixty-seals-melt.md
+++ b/.changeset/sixty-seals-melt.md
@@ -1,0 +1,5 @@
+---
+"servify": patch
+---
+
+Fixed documentation and testing to import macros from the `servify` crate rather than from the `servify_macro` crate, which is re-exported in the `servify` crate.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A macro for effortlessly enabling message passing, inter-process communication, HTTP/TCP server functionality, and more with a unified implementation in struct methods.
 
 ```rs
-#[servify_macro::service(
+#[servify::service(
     impls = [
         Counter_increment_and_get,
         Counter_get_value,
@@ -13,7 +13,7 @@ struct Counter {
     pub count: u32,
 }
 
-#[servify_macro::export]
+#[servify::export]
 impl Counter {
     fn increment_and_get(&mut self, count: u32) -> u32 {
         self.count += count;

--- a/servify/README.md
+++ b/servify/README.md
@@ -3,7 +3,7 @@
 A macro for effortlessly enabling message passing, inter-process communication, HTTP/TCP server functionality, and more with a unified implementation in struct methods.
 
 ```rs
-#[servify_macro::service(
+#[servify::service(
     impls = [
         Counter_increment_and_get,
         Counter_get_value,
@@ -13,7 +13,7 @@ struct Counter {
     pub count: u32,
 }
 
-#[servify_macro::export]
+#[servify::export]
 impl Counter {
     fn increment_and_get(&mut self, count: u32) -> u32 {
         self.count += count;

--- a/servify/tests/simple_counter.rs
+++ b/servify/tests/simple_counter.rs
@@ -1,4 +1,4 @@
-#[servify_macro::service(
+#[servify::service(
     impls = [
         Counter_increment_and_get,
         Counter_get_value,
@@ -8,7 +8,7 @@ struct Counter {
     pub count: u32,
 }
 
-#[servify_macro::export]
+#[servify::export]
 impl Counter {
     fn increment_and_get(&mut self, count: u32) -> u32 {
         self.count += count;

--- a/servify/tests/simple_counter_2.rs
+++ b/servify/tests/simple_counter_2.rs
@@ -1,4 +1,4 @@
-#[servify_macro::service(
+#[servify::service(
     impls = [
         SimpleCounter_increment_and_get,
         SimpleCounter_get,
@@ -10,7 +10,7 @@ struct SimpleCounter {
     pub counter: u32,
 }
 
-#[servify_macro::export]
+#[servify::export]
 impl SimpleCounter {
     fn increment_and_get(&mut self) -> u32 {
         self.counter += 1;

--- a/servify/tests/simple_counter_file_split/get.rs
+++ b/servify/tests/simple_counter_file_split/get.rs
@@ -1,6 +1,6 @@
 use super::SimpleCounter;
 
-#[servify_macro::export]
+#[servify::export]
 impl SimpleCounter {
     fn get(&self) -> u32 {
         self.counter

--- a/servify/tests/simple_counter_file_split/increment.rs
+++ b/servify/tests/simple_counter_file_split/increment.rs
@@ -1,6 +1,6 @@
 use super::SimpleCounter;
 
-#[servify_macro::export]
+#[servify::export]
 impl SimpleCounter {
     fn increment_and_get_ex(&mut self) -> u32 {
         self.counter += 1;

--- a/servify/tests/simple_counter_file_split/mod.rs
+++ b/servify/tests/simple_counter_file_split/mod.rs
@@ -8,7 +8,7 @@ use increment::SimpleCounter_increment_and_get_ex;
 use reset::SimpleCounter_reset;
 use set::SimpleCounter_set;
 
-#[servify_macro::service(
+#[servify::service(
     impls = [
         SimpleCounter_increment_and_get_ex,
         SimpleCounter_get,

--- a/servify/tests/simple_counter_file_split/reset.rs
+++ b/servify/tests/simple_counter_file_split/reset.rs
@@ -1,6 +1,6 @@
 use super::SimpleCounter;
 
-#[servify_macro::export]
+#[servify::export]
 impl SimpleCounter {
     fn reset(&mut self) {
         self.counter = 0;

--- a/servify/tests/simple_counter_file_split/set.rs
+++ b/servify/tests/simple_counter_file_split/set.rs
@@ -1,6 +1,6 @@
 use super::SimpleCounter;
 
-#[servify_macro::export]
+#[servify::export]
 impl SimpleCounter {
     fn set(&mut self, value: u32) {
         self.counter = value;


### PR DESCRIPTION
- close #24 